### PR TITLE
feat: enrich GET /friendships with net balance per friend

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2808,6 +2808,9 @@ const docTemplate = `{
                 "profileId2": {
                     "type": "string"
                 },
+                "slug": {
+                    "type": "string"
+                },
                 "type": {
                     "type": "string"
                 },
@@ -2900,6 +2903,12 @@ const docTemplate = `{
         "dto.FriendshipResponse": {
             "type": "object",
             "properties": {
+                "balancesPerCurrency": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "number"
+                    }
+                },
                 "createdAt": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2802,6 +2802,9 @@
                 "profileId2": {
                     "type": "string"
                 },
+                "slug": {
+                    "type": "string"
+                },
                 "type": {
                     "type": "string"
                 },
@@ -2894,6 +2897,12 @@
         "dto.FriendshipResponse": {
             "type": "object",
             "properties": {
+                "balancesPerCurrency": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "number"
+                    }
+                },
                 "createdAt": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -208,6 +208,8 @@ definitions:
         type: string
       profileId2:
         type: string
+      slug:
+        type: string
       type:
         type: string
       updatedAt:
@@ -268,6 +270,10 @@ definitions:
     type: object
   dto.FriendshipResponse:
     properties:
+      balancesPerCurrency:
+        additionalProperties:
+          type: number
+        type: object
       createdAt:
         type: string
       id:

--- a/internal/adapters/http/handler/friendship_handler.go
+++ b/internal/adapters/http/handler/friendship_handler.go
@@ -15,15 +15,18 @@ import (
 type FriendshipHandler struct {
 	friendshipService service.FriendshipService
 	friendDetailsSvc  service.FriendDetailsService
+	debtService       service.DebtService
 }
 
 func NewFriendshipHandler(
 	friendshipService service.FriendshipService,
 	friendDetailsSvc service.FriendDetailsService,
+	debtService service.DebtService,
 ) *FriendshipHandler {
 	return &FriendshipHandler{
 		friendshipService,
 		friendDetailsSvc,
+		debtService,
 	}
 }
 
@@ -71,7 +74,23 @@ func (fh *FriendshipHandler) HandleGetAll() gin.HandlerFunc {
 			return nil, err
 		}
 
-		return fh.friendshipService.GetAll(ctx.Request.Context(), profileID)
+		friendships, err := fh.friendshipService.GetAll(ctx.Request.Context(), profileID)
+		if err != nil {
+			return nil, err
+		}
+
+		balances, err := fh.debtService.GetNetBalancesByFriend(ctx.Request.Context(), profileID)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range friendships {
+			if b, ok := balances[friendships[i].ProfileID]; ok {
+				friendships[i].BalancesPerCurrency = b
+			}
+		}
+
+		return friendships, nil
 	})
 }
 

--- a/internal/adapters/http/handler/handlers.go
+++ b/internal/adapters/http/handler/handlers.go
@@ -27,7 +27,7 @@ type Handlers struct {
 func ProvideHandlers(services *provider.Services) *Handlers {
 	return &Handlers{
 		NewAuthHandler(services.Auth, services.OAuth, services.Session),
-		NewFriendshipHandler(services.Friendship, services.FriendDetails),
+		NewFriendshipHandler(services.Friendship, services.FriendDetails, services.Debt),
 		NewFriendshipRequestHandler(services.FriendshipRequest),
 		NewProfileHandler(services.Profile),
 		NewTransferMethodHandler(services.TransferMethod),

--- a/internal/domain/dto/friendship_dto.go
+++ b/internal/domain/dto/friendship_dto.go
@@ -12,10 +12,11 @@ type NewAnonymousFriendshipRequest struct {
 
 type FriendshipResponse struct {
 	BaseDTO
-	Type          string    `json:"type"`
-	ProfileID     uuid.UUID `json:"profileId"`
-	ProfileName   string    `json:"profileName"`
-	ProfileAvatar string    `json:"profileAvatar"`
+	Type                string                     `json:"type"`
+	ProfileID           uuid.UUID                  `json:"profileId"`
+	ProfileName         string                     `json:"profileName"`
+	ProfileAvatar       string                     `json:"profileAvatar"`
+	BalancesPerCurrency map[string]decimal.Decimal `json:"balancesPerCurrency,omitempty"`
 }
 
 type FriendshipWithProfile struct {

--- a/internal/domain/mapper/debt_transaction_mapper.go
+++ b/internal/domain/mapper/debt_transaction_mapper.go
@@ -37,34 +37,25 @@ func calculateBalances(userAssociatedIDs []uuid.UUID, transactions []debts.DebtT
 	totalLent, totalBorrowed := decimal.Zero, decimal.Zero
 	history := make([]dto.FriendTransactionItem, 0, len(transactions))
 
-	// Create a map for quick lookup of user's associated IDs
-	userIDMap := make(map[uuid.UUID]struct{}, len(userAssociatedIDs))
-	for _, id := range userAssociatedIDs {
-		userIDMap[id] = struct{}{}
-	}
+	userIDMap := buildIDSet(userAssociatedIDs)
 
 	for _, tx := range transactions {
+		dir := classifyTransaction(tx, userIDMap)
+		if dir == 0 {
+			logger.Errorf("orphaned transaction %s", tx.ID)
+			continue
+		}
+
 		var transactionType string
 		var amount decimal.Decimal
-
-		// Check if user (or their associated profiles) is the lender or borrower
-		_, userIsLender := userIDMap[tx.LenderProfileID]
-		_, userIsBorrower := userIDMap[tx.BorrowerProfileID]
-
-		if userIsLender && !userIsBorrower {
-			// User is the lender
+		if dir > 0 {
 			transactionType = "LENT"
 			amount = tx.Amount
 			totalLent = totalLent.Add(tx.Amount)
-		} else if userIsBorrower && !userIsLender {
-			// User is the borrower
+		} else {
 			transactionType = "BORROWED"
 			amount = tx.Amount
 			totalBorrowed = totalBorrowed.Add(tx.Amount)
-		} else {
-			// Skip transactions where user is both or neither (shouldn't happen)
-			logger.Errorf("orphaned transaction %s. userIsLender: %t. userIsBorrower: %t", tx.ID, userIsLender, userIsBorrower)
-			continue
 		}
 
 		history = append(history, dto.FriendTransactionItem{
@@ -77,6 +68,29 @@ func calculateBalances(userAssociatedIDs []uuid.UUID, transactions []debts.DebtT
 	}
 
 	return totalLent, totalBorrowed, history
+}
+
+// buildIDSet creates a set for fast lookup.
+func buildIDSet(ids []uuid.UUID) map[uuid.UUID]struct{} {
+	s := make(map[uuid.UUID]struct{}, len(ids))
+	for _, id := range ids {
+		s[id] = struct{}{}
+	}
+	return s
+}
+
+// classifyTransaction returns +1 if user is lender, -1 if borrower, 0 if ambiguous.
+func classifyTransaction(tx debts.DebtTransaction, userIDSet map[uuid.UUID]struct{}) int {
+	_, userIsLender := userIDSet[tx.LenderProfileID]
+	_, userIsBorrower := userIDSet[tx.BorrowerProfileID]
+	switch {
+	case userIsLender && !userIsBorrower:
+		return 1
+	case userIsBorrower && !userIsLender:
+		return -1
+	default:
+		return 0
+	}
 }
 
 func DebtTransactionToResponse(userProfileID uuid.UUID, transaction debts.DebtTransaction, profilesByID map[uuid.UUID]dto.ProfileResponse) dto.DebtTransactionResponse {
@@ -113,4 +127,35 @@ func DebtTransactionSimpleMapper(userProfileID uuid.UUID, profilesByID map[uuid.
 	return func(transaction debts.DebtTransaction) dto.DebtTransactionResponse {
 		return DebtTransactionToResponse(userProfileID, transaction, profilesByID)
 	}
+}
+
+// NetBalanceByFriend groups transactions by counterparty and computes net balance per currency.
+// Returns map[counterpartyProfileID]map[currency]netBalance.
+func NetBalanceByFriend(transactions []debts.DebtTransaction, userAssociatedIDs []uuid.UUID) map[uuid.UUID]map[string]decimal.Decimal {
+	userIDSet := buildIDSet(userAssociatedIDs)
+
+	result := make(map[uuid.UUID]map[string]decimal.Decimal)
+	for _, tx := range transactions {
+		dir := classifyTransaction(tx, userIDSet)
+		if dir == 0 {
+			continue
+		}
+
+		var counterparty uuid.UUID
+		var amount decimal.Decimal
+		if dir > 0 {
+			counterparty = tx.BorrowerProfileID
+			amount = tx.Amount
+		} else {
+			counterparty = tx.LenderProfileID
+			amount = tx.Amount.Neg()
+		}
+
+		if result[counterparty] == nil {
+			result[counterparty] = make(map[string]decimal.Decimal)
+		}
+		result[counterparty][tx.Currency] = result[counterparty][tx.Currency].Add(amount)
+	}
+
+	return result
 }

--- a/internal/domain/service/debt_service.go
+++ b/internal/domain/service/debt_service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/itsLeonB/ezutil/v2"
 	"github.com/itsLeonB/go-crud"
 	"github.com/itsLeonB/ungerr"
+	"github.com/shopspring/decimal"
 	"gorm.io/datatypes"
 )
 
@@ -182,6 +183,65 @@ func (ds *debtServiceImpl) GetAllByProfileIDs(ctx context.Context, userProfileID
 
 	transactions, err := ds.debtTransactionRepository.FindAllByMultipleProfileIDs(ctx, userIDs, friendIDs)
 	return transactions, userIDs, err
+}
+
+func (ds *debtServiceImpl) GetNetBalancesByFriend(ctx context.Context, profileID uuid.UUID) (map[uuid.UUID]map[string]decimal.Decimal, error) {
+	ctx, span := otel.Tracer.Start(ctx, "DebtService.GetNetBalancesByFriend")
+	defer span.End()
+
+	profileIDs, err := ds.profileService.GetAssociatedIDs(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+
+	transactions, err := ds.debtTransactionRepository.FindAllByProfileIDs(ctx, profileIDs, -1, false)
+	if err != nil {
+		return nil, err
+	}
+
+	raw := mapper.NetBalanceByFriend(transactions, profileIDs)
+
+	// Consolidate anon profile IDs to their real profiles
+	counterpartyIDs := make([]uuid.UUID, 0, len(raw))
+	for id := range raw {
+		counterpartyIDs = append(counterpartyIDs, id)
+	}
+	if len(counterpartyIDs) == 0 {
+		return raw, nil
+	}
+
+	profiles, err := ds.profileService.GetByIDs(ctx, counterpartyIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	consolidated := make(map[uuid.UUID]map[string]decimal.Decimal, len(raw))
+	for cpID, currencies := range raw {
+		canonicalID := cpID
+		if p, ok := profiles[cpID]; ok && p.RealProfileID != uuid.Nil {
+			canonicalID = p.RealProfileID
+		}
+		if consolidated[canonicalID] == nil {
+			consolidated[canonicalID] = make(map[string]decimal.Decimal)
+		}
+		for cur, amt := range currencies {
+			consolidated[canonicalID][cur] = consolidated[canonicalID][cur].Add(amt)
+		}
+	}
+
+	// Remove zero-balance currencies
+	for id, currencies := range consolidated {
+		for cur, amt := range currencies {
+			if amt.IsZero() {
+				delete(consolidated[id], cur)
+			}
+		}
+		if len(currencies) == 0 {
+			delete(consolidated, id)
+		}
+	}
+
+	return consolidated, nil
 }
 
 func (ds *debtServiceImpl) GetRecent(ctx context.Context, profileID uuid.UUID) ([]dto.DebtTransactionResponse, error) {

--- a/internal/domain/service/services.go
+++ b/internal/domain/service/services.go
@@ -10,6 +10,7 @@ import (
 	"github.com/itsLeonB/cashback/internal/domain/entity/expenses"
 	"github.com/itsLeonB/cashback/internal/domain/entity/users"
 	"github.com/itsLeonB/cashback/internal/domain/message"
+	"github.com/shopspring/decimal"
 )
 
 type UserService interface {
@@ -95,6 +96,7 @@ type DebtService interface {
 	GetTransactions(ctx context.Context, userProfileID uuid.UUID) ([]dto.DebtTransactionResponse, error)
 	GetAllByProfileIDs(ctx context.Context, userProfileID, friendProfileID uuid.UUID) ([]debts.DebtTransaction, []uuid.UUID, error)
 	GetTransactionSummary(ctx context.Context, profileID uuid.UUID) (map[string]dto.FriendBalance, error)
+	GetNetBalancesByFriend(ctx context.Context, profileID uuid.UUID) (map[uuid.UUID]map[string]decimal.Decimal, error)
 	GetRecent(ctx context.Context, profileID uuid.UUID) ([]dto.DebtTransactionResponse, error)
 
 	ConstructNotification(ctx context.Context, msg message.DebtCreated) (entity.Notification, error)


### PR DESCRIPTION
## Summary

Enriches the `GET /friendships` endpoint to return `balancesPerCurrency` (net balance per currency) for each friend, enabling the frontend to display balances inline on the friends list.

## Changes

- **DTO**: Added `BalancesPerCurrency map[string]decimal.Decimal` to `FriendshipResponse`
- **Mapper**: Added `NetBalanceByFriend` function + extracted shared helpers (`buildIDSet`, `classifyTransaction`) to deduplicate logic with `calculateBalances`
- **DebtService**: Added `GetNetBalancesByFriend` that fetches all user transactions once, groups by counterparty, consolidates anon→real profile IDs, and omits zero balances
- **Handler**: Orchestrated balance enrichment at the handler level (avoids circular dep since DebtService depends on FriendshipService)
- **Wiring**: Passed `DebtService` into `FriendshipHandler`

## Behavior

- Friends with transactions: `balancesPerCurrency` contains `{ "IDR": "50000", "USD": "-10" }` etc.
- Friends with no transactions: field is omitted (`omitempty`)
- Positive = friend owes user, negative = user owes friend
- Zero-balance currencies are excluded from the map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Friendship responses now include per-friend, per-currency net balance information.

* **Documentation**
  * Public API docs updated to document the new balancesPerCurrency field and an added friend "slug" property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->