### PR TITLE
feat: use NATS KV as shared backing store for state verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ PUSH_VAPID_PUBLIC_KEY=your-vapid-public-key
 PUSH_VAPID_SUBJECT=mailto:your-email@example.com
 
 NATS_URL=nats://localhost:4222
+NATS_STATE_STORE_BUCKET=state-store
 
 GOOSE_DRIVER=postgres
 GOOSE_DBSTRING=postgres://postgres:postgres@localhost:5432/cashback

--- a/internal/adapters/core/service/store/nats_kv_state_store.go
+++ b/internal/adapters/core/service/store/nats_kv_state_store.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/itsLeonB/ungerr"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type natsKVStateStore struct {
+	kv jetstream.KeyValue
+}
+
+func NewNATSKVStateStore(kv jetstream.KeyValue) *natsKVStateStore {
+	return &natsKVStateStore{kv: kv}
+}
+
+func (s *natsKVStateStore) Store(ctx context.Context, state string, expiry time.Duration) error {
+	_, err := s.kv.Create(ctx, s.constructKey(state), []byte(state), jetstream.KeyTTL(expiry))
+	if err != nil {
+		return ungerr.Wrap(err, "error storing state in NATS KV")
+	}
+	return nil
+}
+
+func (s *natsKVStateStore) VerifyAndDelete(ctx context.Context, state string) error {
+	key := s.constructKey(state)
+	_, err := s.kv.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return ungerr.BadRequestError("invalid state")
+		}
+		return ungerr.Wrap(err, "error verifying state in NATS KV")
+	}
+
+	if err := s.kv.Delete(ctx, key); err != nil {
+		return ungerr.Wrap(err, "error deleting state from NATS KV")
+	}
+	return nil
+}
+
+func (s *natsKVStateStore) Shutdown() error {
+	return nil
+}
+
+func (s *natsKVStateStore) constructKey(state string) string {
+	return fmt.Sprintf("state.%s", state)
+}

--- a/internal/adapters/core/service/store/nats_kv_state_store.go
+++ b/internal/adapters/core/service/store/nats_kv_state_store.go
@@ -28,7 +28,7 @@ func (s *natsKVStateStore) Store(ctx context.Context, state string, expiry time.
 
 func (s *natsKVStateStore) VerifyAndDelete(ctx context.Context, state string) error {
 	key := s.constructKey(state)
-	_, err := s.kv.Get(ctx, key)
+	entry, err := s.kv.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return ungerr.BadRequestError("invalid state")
@@ -36,8 +36,8 @@ func (s *natsKVStateStore) VerifyAndDelete(ctx context.Context, state string) er
 		return ungerr.Wrap(err, "error verifying state in NATS KV")
 	}
 
-	if err := s.kv.Delete(ctx, key); err != nil {
-		return ungerr.Wrap(err, "error deleting state from NATS KV")
+	if err := s.kv.Delete(ctx, key, jetstream.LastRevision(entry.Revision())); err != nil {
+		return ungerr.BadRequestError("invalid state")
 	}
 	return nil
 }

--- a/internal/adapters/core/service/store/nats_kv_state_store.go
+++ b/internal/adapters/core/service/store/nats_kv_state_store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/itsLeonB/cashback/internal/core/otel"
 	"github.com/itsLeonB/ungerr"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -19,14 +20,21 @@ func NewNATSKVStateStore(kv jetstream.KeyValue) *natsKVStateStore {
 }
 
 func (s *natsKVStateStore) Store(ctx context.Context, state string, expiry time.Duration) error {
+	ctx, span := otel.Tracer.Start(ctx, "natsKVStateStore.Store")
+	defer span.End()
+
 	_, err := s.kv.Create(ctx, s.constructKey(state), []byte(state), jetstream.KeyTTL(expiry))
 	if err != nil {
 		return ungerr.Wrap(err, "error storing state in NATS KV")
 	}
+
 	return nil
 }
 
 func (s *natsKVStateStore) VerifyAndDelete(ctx context.Context, state string) error {
+	ctx, span := otel.Tracer.Start(ctx, "natsKVStateStore.VerifyAndDelete")
+	defer span.End()
+
 	key := s.constructKey(state)
 	entry, err := s.kv.Get(ctx, key)
 	if err != nil {
@@ -39,6 +47,7 @@ func (s *natsKVStateStore) VerifyAndDelete(ctx context.Context, state string) er
 	if err := s.kv.Delete(ctx, key, jetstream.LastRevision(entry.Revision())); err != nil {
 		return ungerr.BadRequestError("invalid state")
 	}
+
 	return nil
 }
 

--- a/internal/adapters/core/service/store/nats_kv_state_store_test.go
+++ b/internal/adapters/core/service/store/nats_kv_state_store_test.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type mockKV struct {
+	entries map[string][]byte
+	jetstream.KeyValue
+}
+
+func newMockKV() *mockKV {
+	return &mockKV{entries: make(map[string][]byte)}
+}
+
+func (m *mockKV) Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error) {
+	if _, ok := m.entries[key]; ok {
+		return 0, jetstream.ErrKeyExists
+	}
+	m.entries[key] = value
+	return 1, nil
+}
+
+func (m *mockKV) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	if _, ok := m.entries[key]; !ok {
+		return nil, jetstream.ErrKeyNotFound
+	}
+	return nil, nil
+}
+
+func (m *mockKV) Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error {
+	delete(m.entries, key)
+	return nil
+}
+
+func TestNATSKVStateStore_Store(t *testing.T) {
+	kv := newMockKV()
+	s := NewNATSKVStateStore(kv)
+
+	err := s.Store(context.Background(), "abc123", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := kv.entries["state.abc123"]; !ok {
+		t.Fatal("expected key to be stored")
+	}
+}
+
+func TestNATSKVStateStore_Store_Duplicate(t *testing.T) {
+	kv := newMockKV()
+	s := NewNATSKVStateStore(kv)
+
+	_ = s.Store(context.Background(), "abc123", 5*time.Minute)
+	err := s.Store(context.Background(), "abc123", 5*time.Minute)
+	if err == nil {
+		t.Fatal("expected error on duplicate store")
+	}
+}
+
+func TestNATSKVStateStore_VerifyAndDelete(t *testing.T) {
+	kv := newMockKV()
+	s := NewNATSKVStateStore(kv)
+
+	_ = s.Store(context.Background(), "abc123", 5*time.Minute)
+
+	err := s.VerifyAndDelete(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := kv.entries["state.abc123"]; ok {
+		t.Fatal("expected key to be deleted")
+	}
+}
+
+func TestNATSKVStateStore_VerifyAndDelete_NotFound(t *testing.T) {
+	kv := newMockKV()
+	s := NewNATSKVStateStore(kv)
+
+	err := s.VerifyAndDelete(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent state")
+	}
+}
+
+func TestNATSKVStateStore_Shutdown(t *testing.T) {
+	kv := newMockKV()
+	s := NewNATSKVStateStore(kv)
+
+	if err := s.Shutdown(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/adapters/core/service/store/nats_kv_state_store_test.go
+++ b/internal/adapters/core/service/store/nats_kv_state_store_test.go
@@ -29,13 +29,20 @@ func (m *mockKV) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, 
 	if _, ok := m.entries[key]; !ok {
 		return nil, jetstream.ErrKeyNotFound
 	}
-	return nil, nil
+	return &mockEntry{revision: 1}, nil
 }
 
 func (m *mockKV) Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error {
 	delete(m.entries, key)
 	return nil
 }
+
+type mockEntry struct {
+	jetstream.KeyValueEntry
+	revision uint64
+}
+
+func (e *mockEntry) Revision() uint64 { return e.revision }
 
 func TestNATSKVStateStore_Store(t *testing.T) {
 	kv := newMockKV()

--- a/internal/core/config/auth_config.go
+++ b/internal/core/config/auth_config.go
@@ -7,6 +7,7 @@ type Auth struct {
 	TokenDuration time.Duration `split_words:"true" default:"24h"`
 	Issuer        string        `default:"cashback"`
 	HashCost      int           `split_words:"true" default:"10"`
+	StateStore    string        `split_words:"true" default:"inmemory"`
 }
 
 func (Auth) Prefix() string {

--- a/internal/core/config/nats_config.go
+++ b/internal/core/config/nats_config.go
@@ -1,7 +1,8 @@
 package config
 
 type NATS struct {
-	Url string `required:"true"`
+	Url              string `required:"true"`
+	StateStoreBucket string `split_words:"true" default:"state-store"`
 }
 
 func (NATS) Prefix() string {

--- a/internal/core/service/store/state_store.go
+++ b/internal/core/service/store/state_store.go
@@ -17,7 +17,8 @@ type StateStore interface {
 }
 
 func NewStateStore(js jetstream.JetStream) (StateStore, error) {
-	if config.Global.StateStore == "nats" {
+	switch config.Global.StateStore {
+	case "nats":
 		ctx := context.Background()
 		kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
 			Bucket:         config.Global.StateStoreBucket,
@@ -28,7 +29,9 @@ func NewStateStore(js jetstream.JetStream) (StateStore, error) {
 			return nil, ungerr.Wrap(err, "error creating NATS KV state store bucket")
 		}
 		return store.NewNATSKVStateStore(kv), nil
+	case "inmemory":
+		return store.NewInMemoryStateStore(), nil
+	default:
+		return nil, ungerr.Unknownf("unsupported AUTH_STATE_STORE value: %q", config.Global.StateStore)
 	}
-
-	return store.NewInMemoryStateStore(), nil
 }

--- a/internal/core/service/store/state_store.go
+++ b/internal/core/service/store/state_store.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"github.com/itsLeonB/cashback/internal/adapters/core/service/store"
+	"github.com/itsLeonB/cashback/internal/core/config"
+	"github.com/itsLeonB/ungerr"
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 type StateStore interface {
@@ -13,6 +16,19 @@ type StateStore interface {
 	Shutdown() error
 }
 
-func NewStateStore() StateStore {
-	return store.NewInMemoryStateStore()
+func NewStateStore(js jetstream.JetStream) (StateStore, error) {
+	if config.Global.StateStore == "nats" {
+		ctx := context.Background()
+		kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+			Bucket:         config.Global.StateStoreBucket,
+			History:        1,
+			LimitMarkerTTL: 10 * time.Minute,
+		})
+		if err != nil {
+			return nil, ungerr.Wrap(err, "error creating NATS KV state store bucket")
+		}
+		return store.NewNATSKVStateStore(kv), nil
+	}
+
+	return store.NewInMemoryStateStore(), nil
 }

--- a/internal/provider/core_service_provider.go
+++ b/internal/provider/core_service_provider.go
@@ -57,8 +57,6 @@ func ProvideCoreServices() (*CoreServices, error) {
 		return nil, err
 	}
 
-	stateStore := store.NewStateStore()
-
 	ocrClient, err := ocr.NewOCRClient()
 	if err != nil {
 		return nil, err
@@ -73,6 +71,12 @@ func ProvideCoreServices() (*CoreServices, error) {
 	if err != nil {
 		nc.Close()
 		return nil, ungerr.Wrap(err, "error creating JetStream context")
+	}
+
+	stateStore, err := store.NewStateStore(js)
+	if err != nil {
+		nc.Close()
+		return nil, err
 	}
 
 	taskQueue := adapters.NewNATSTaskQueue(js)


### PR DESCRIPTION
## Summary

Resolves #50

Replaces the in-memory state store with an optional NATS KV-backed implementation for OAuth state verification, enabling correct behavior across multiple replicas and restarts.

## Changes

- Added `NATSKVStateStore` adapter using NATS JetStream KV API with per-key TTL
- Updated `NewStateStore()` factory to toggle between `inmemory` and `nats` via `AUTH_STATE_STORE` env var
- Added configurable bucket name via `NATS_STATE_STORE_BUCKET` (default: `state-store`)
- Wired KV bucket creation into `ProvideCoreServices()` startup
- Added unit tests for the NATS KV adapter

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `AUTH_STATE_STORE` | `inmemory` | Set to `nats` to use shared NATS KV store |
| `NATS_STATE_STORE_BUCKET` | `state-store` | NATS KV bucket name for state storage |

## Testing

- `make build-all` ✅
- `make test` ✅
- Lint passes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for NATS JetStream as a state store backend. Users can now configure persistent state storage via environment variables instead of being limited to in-memory storage.

* **Tests**
  * Added comprehensive test coverage for the new NATS state store implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->