### PR TITLE
feat(worker): add panic recovery for workers

### DIFF
--- a/internal/adapters/worker/scheduler/scheduler.go
+++ b/internal/adapters/worker/scheduler/scheduler.go
@@ -3,6 +3,8 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"fmt"
+	"runtime/debug"
 
 	"github.com/itsLeonB/cashback/internal/core/logger"
 	"github.com/itsLeonB/cashback/internal/core/otel"
@@ -11,6 +13,7 @@ import (
 	"github.com/itsLeonB/cashback/internal/provider"
 	"github.com/itsLeonB/ungerr"
 	"github.com/robfig/cron/v3"
+	"go.opentelemetry.io/otel/codes"
 )
 
 type Scheduler struct {
@@ -40,6 +43,16 @@ func (s *Scheduler) jobWrapper(jobName string, jobFn func(context.Context) error
 	return func() {
 		ctx, span := otel.Tracer.Start(context.Background(), jobName)
 		defer span.End()
+
+		defer func() {
+			if r := recover(); r != nil {
+				stack := debug.Stack()
+				err := fmt.Errorf("panic in job %s: %v\n%s", jobName, r, stack)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "panic recovered")
+				logger.Errorf("panic in job %s: %v\n%s", jobName, r, stack)
+			}
+		}()
 
 		logger.Infof("starting %s...", jobName)
 		if err := jobFn(ctx); err != nil {

--- a/internal/adapters/worker/scheduler/scheduler_test.go
+++ b/internal/adapters/worker/scheduler/scheduler_test.go
@@ -1,0 +1,25 @@
+package scheduler
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/itsLeonB/cashback/internal/core/logger"
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	logger.Init("test")
+	os.Exit(m.Run())
+}
+
+func TestJobWrapper_PanicRecovery(t *testing.T) {
+	s := &Scheduler{cron: cron.New()}
+	wrapped := s.jobWrapper("test-panic-job", func(ctx context.Context) error {
+		panic("test panic")
+	})
+
+	assert.NotPanics(t, wrapped)
+}

--- a/internal/adapters/worker/subscriber/middlewares.go
+++ b/internal/adapters/worker/subscriber/middlewares.go
@@ -2,17 +2,34 @@ package subscriber
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 
 	"github.com/itsLeonB/cashback/internal/core/logger"
 	"github.com/itsLeonB/cashback/internal/core/otel"
 	"github.com/itsLeonB/cashback/internal/core/service/queue"
 	"github.com/itsLeonB/ezutil/v2"
 	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel/codes"
 )
 
 func withLogging[T queue.TaskMessage](taskType string, handler func(context.Context, T) error) jetstream.MessageHandler {
 	return func(msg jetstream.Msg) {
 		logger.Infof("received new task %s", taskType)
+
+		ctx, span := otel.Tracer.Start(context.Background(), taskType)
+		defer span.End()
+
+		defer func() {
+			if r := recover(); r != nil {
+				stack := debug.Stack()
+				err := fmt.Errorf("panic in task %s: %v\n%s", taskType, r, stack)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "panic recovered")
+				logger.Errorf("panic in task %s: %v\n%s", taskType, r, stack)
+				_ = msg.Nak()
+			}
+		}()
 
 		parsed, err := ezutil.Unmarshal[T](msg.Data())
 		if err != nil {
@@ -20,9 +37,6 @@ func withLogging[T queue.TaskMessage](taskType string, handler func(context.Cont
 			_ = msg.Nak()
 			return
 		}
-
-		ctx, span := otel.Tracer.Start(context.Background(), parsed.Type())
-		defer span.End()
 
 		if err := handler(ctx, parsed); err != nil {
 			logger.Errorf("error processing %s task: %v", taskType, err)

--- a/internal/adapters/worker/subscriber/middlewares_test.go
+++ b/internal/adapters/worker/subscriber/middlewares_test.go
@@ -1,0 +1,48 @@
+package subscriber
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/itsLeonB/cashback/internal/core/logger"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	logger.Init("test")
+	os.Exit(m.Run())
+}
+
+type mockMsg struct {
+	jetstream.Msg
+	nakCalled bool
+}
+
+func (m *mockMsg) Data() []byte {
+	return []byte(`{"type":"test"}`)
+}
+
+func (m *mockMsg) Nak() error {
+	m.nakCalled = true
+	return nil
+}
+
+type testTask struct {
+	TaskType string `json:"type"`
+}
+
+func (t testTask) Type() string {
+	return t.TaskType
+}
+
+func TestWithLogging_PanicRecovery(t *testing.T) {
+	msg := &mockMsg{}
+	handler := withLogging[testTask]("test-task", func(ctx context.Context, task testTask) error {
+		panic("test panic")
+	})
+
+	assert.NotPanics(t, func() { handler(msg) })
+	assert.True(t, msg.nakCalled)
+}


### PR DESCRIPTION
Closes #25

## Changes
- Add panic recovery with stack trace logging to scheduler `jobWrapper`
- Add panic recovery with stack trace logging to subscriber `withLogging` middleware
- Record panics on OTel spans with `RecordError` and `SetStatus`
- Nak messages on subscriber panic so they get retried

## Tests Added
- `scheduler_test.go` — verifies panicking job doesn't crash the scheduler
- `middlewares_test.go` — verifies panicking handler doesn't crash the subscriber and Nak is called

## Verified
- `make lint` — 0 issues
- `make build-all` — all binaries compile
- `make test` — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Background job execution and task processing now include enhanced error recovery mechanisms to maintain system stability.
  * Error information is automatically captured and tracked through telemetry integration for improved visibility into system operations.

* **Tests**
  * Added comprehensive test coverage to validate error recovery behavior in scheduled jobs and task processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->