### PR TITLE
feat(auth): extract business logic into hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work.sum
 
 bin/
 tmp/
+.kimchi/

--- a/internal/domain/service/auth_hooks.go
+++ b/internal/domain/service/auth_hooks.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// AuthHooks holds optional callbacks that allow application-specific business
+// logic to be injected into the authentication flow without coupling the auth
+// service layer to concrete implementations. All fields are optional; nil
+// fields are treated as no-ops.
+type AuthHooks struct {
+	// BeforeLogout runs before the session is revoked during logout. It is
+	// called after the request is validated but before session deletion. Errors
+	// returned by this hook are non-blocking and do not abort the logout flow.
+	//
+	// Use cases: unsubscribe push notifications, emit audit events.
+	BeforeLogout func(ctx context.Context, sessionID uuid.UUID) error
+
+	// AfterEmailVerified runs after a user's email is successfully verified.
+	// It receives the raw JWT claims (access token) so the hook can extract
+	// application-specific data embedded by ClaimsBuilder, such as a user's
+	// slug. Errors returned by this hook are blocking: they abort the
+	// verification flow and roll back the transaction.
+	//
+	// Use cases: auto-create profile via friendship service, send welcome email.
+	AfterEmailVerified func(ctx context.Context, userID uuid.UUID, profileID uuid.UUID, claims map[string]any) error
+
+	// AfterOAuthLogin runs after a successful OAuth authentication, regardless
+	// of whether the user is new or returning. The isNewUser flag distinguishes
+	// between first-time registration and existing account login. Errors
+	// returned by this hook are non-blocking.
+	//
+	// Use cases: record referral for new OAuth users, sync profile data.
+	AfterOAuthLogin func(ctx context.Context, userID uuid.UUID, provider string, isNewUser bool) error
+
+	// ClaimsBuilder is called whenever a JWT access token is being issued
+	// (during both login and token refresh). It receives the base claims
+	// already set by the session service (sub, exp, iat, sid) and returns a
+	// modified or augmented map to embed in the token. Errors returned by this
+	// hook abort token issuance.
+	//
+	// This hook lives on AuthHooks for discoverability, but it is wired into
+	// SessionService (not AuthService) because claims are built during token
+	// creation. Extract ClaimsBuilder from the hooks value and pass it to
+	// NewSessionService.
+	//
+	// Use cases: embed slug, tier, or other app-specific fields into the JWT.
+	ClaimsBuilder func(ctx context.Context, userID uuid.UUID, baseClaims map[string]any) (map[string]any, error)
+}
+
+// CallBeforeLogout invokes BeforeLogout if it is non-nil. Errors are returned
+// to the caller so the caller can decide whether to block (the hook contract
+// says they should be logged, not returned).
+func (h AuthHooks) CallBeforeLogout(ctx context.Context, sessionID uuid.UUID) error {
+	if h.BeforeLogout == nil {
+		return nil
+	}
+	return h.BeforeLogout(ctx, sessionID)
+}
+
+// CallAfterEmailVerified invokes AfterEmailVerified if it is non-nil.
+func (h AuthHooks) CallAfterEmailVerified(ctx context.Context, userID, profileID uuid.UUID, claims map[string]any) error {
+	if h.AfterEmailVerified == nil {
+		return nil
+	}
+	return h.AfterEmailVerified(ctx, userID, profileID, claims)
+}
+
+// CallAfterOAuthLogin invokes AfterOAuthLogin if it is non-nil.
+func (h AuthHooks) CallAfterOAuthLogin(ctx context.Context, userID uuid.UUID, provider string, isNewUser bool) error {
+	if h.AfterOAuthLogin == nil {
+		return nil
+	}
+	return h.AfterOAuthLogin(ctx, userID, provider, isNewUser)
+}

--- a/internal/domain/service/auth_service.go
+++ b/internal/domain/service/auth_service.go
@@ -30,11 +30,9 @@ type authServiceImpl struct {
 	mailSvc          mail.MailService
 	verificationURL  string
 	resetPasswordURL string
-	pushSvc          PushNotificationService
 	sessionSvc       SessionService
-	profileSvc       ProfileService
-	friendshipSvc    FriendshipService
 	sessionCache     cache.Cache[uuid.UUID]
+	hooks            AuthHooks
 }
 
 func NewAuthService(
@@ -45,11 +43,9 @@ func NewAuthService(
 	verificationURL string,
 	resetPasswordURL string,
 	hashCost int,
-	pushSvc PushNotificationService,
 	sessionSvc SessionService,
-	profileSvc ProfileService,
-	friendshipSvc FriendshipService,
 	sessionCache cache.Cache[uuid.UUID],
+	hooks AuthHooks,
 ) AuthService {
 	return &authServiceImpl{
 		sekure.NewHashService(hashCost),
@@ -59,11 +55,9 @@ func NewAuthService(
 		mailSvc,
 		verificationURL,
 		resetPasswordURL,
-		pushSvc,
 		sessionSvc,
-		profileSvc,
-		friendshipSvc,
 		sessionCache,
+		hooks,
 	}
 }
 
@@ -282,44 +276,14 @@ func (as *authServiceImpl) VerifyRegistration(ctx context.Context, token string)
 			return err
 		}
 
-		// Handle slug-based profile association
-		if slug, ok := claims.Data["slug"].(string); ok && slug != "" {
-			if err := as.associateBySlug(ctx, user.Profile.ID, slug); err != nil {
-				return err
-			}
+		if err := as.hooks.CallAfterEmailVerified(ctx, user.ID, user.Profile.ID, claims.Data); err != nil {
+			return err
 		}
 
 		response, err = as.sessionSvc.CreateTokenAndSession(ctx, user)
 		return err
 	})
 	return response, err
-}
-
-func (as *authServiceImpl) associateBySlug(ctx context.Context, newProfileID uuid.UUID, slug string) error {
-	anonProfile, err := as.profileSvc.FindBySlug(ctx, slug)
-	if err != nil {
-		return err
-	}
-
-	// Find the owner of the anonymous profile via friendship
-	friendships, err := as.friendshipSvc.GetAll(ctx, anonProfile.ID)
-	if err != nil {
-		return err
-	}
-	if len(friendships) == 0 {
-		return fmt.Errorf("no friendship found for slug %s", slug)
-	}
-
-	ownerProfileID := friendships[0].ProfileID
-
-	// Create real friendship between owner and new user
-	_, err = as.friendshipSvc.CreateReal(ctx, ownerProfileID, newProfileID)
-	if err != nil {
-		return err
-	}
-
-	// Create RelatedProfile association
-	return as.profileSvc.Associate(ctx, ownerProfileID, newProfileID, anonProfile.ID)
 }
 
 func (as *authServiceImpl) SendPasswordReset(ctx context.Context, email string) error {
@@ -416,9 +380,10 @@ func (as *authServiceImpl) Logout(ctx context.Context, sessionID uuid.UUID) erro
 	ctx, span := otel.Tracer.Start(ctx, "AuthService.Logout")
 	defer span.End()
 
-	// Clean up push subscriptions for this session (failure must not block logout)
-	if err := as.pushSvc.UnsubscribeBySession(ctx, sessionID); err != nil {
-		logger.Error(err)
+	if as.hooks.BeforeLogout != nil {
+		if err := as.hooks.BeforeLogout(ctx, sessionID); err != nil {
+			logger.Error(err)
+		}
 	}
 
 	as.sessionCache.Delete(sessionID.String())

--- a/internal/domain/service/auth_service_test.go
+++ b/internal/domain/service/auth_service_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func newTestAuthService(jwtSvc sekure.JWTService, userSvc service.UserService, sessionSvc service.SessionService, sessionCache cache.Cache[uuid.UUID]) service.AuthService {
-	return service.NewAuthService(jwtSvc, nil, userSvc, nil, "", "", 10, nil, sessionSvc, nil, nil, sessionCache)
+	return service.NewAuthService(jwtSvc, nil, userSvc, nil, "", "", 10, sessionSvc, sessionCache, service.AuthHooks{})
 }
 
 func TestVerifyToken_Success(t *testing.T) {

--- a/internal/domain/service/oauth_service.go
+++ b/internal/domain/service/oauth_service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"time"
 
+	"github.com/itsLeonB/cashback/internal/core/logger"
 	"github.com/itsLeonB/cashback/internal/core/otel"
 	"github.com/itsLeonB/cashback/internal/core/service/store"
 	"github.com/itsLeonB/cashback/internal/domain/dto"
@@ -22,6 +23,7 @@ type oauthServiceImpl struct {
 	stateStore       store.StateStore
 	userSvc          UserService
 	sessionSvc       SessionService
+	hooks            AuthHooks
 }
 
 func NewOAuthService(
@@ -31,6 +33,7 @@ func NewOAuthService(
 	stateStore store.StateStore,
 	userSvc UserService,
 	sessionSvc SessionService,
+	hooks AuthHooks,
 ) OAuthService {
 	return &oauthServiceImpl{
 		transactor:       transactor,
@@ -39,6 +42,7 @@ func NewOAuthService(
 		stateStore:       stateStore,
 		userSvc:          userSvc,
 		sessionSvc:       sessionSvc,
+		hooks:            hooks,
 	}
 }
 
@@ -67,7 +71,14 @@ func (as *oauthServiceImpl) HandleOAuthCallback(ctx context.Context, data dto.OA
 	ctx, span := otel.Tracer.Start(ctx, "OAuthService.HandleOAuthCallback")
 	defer span.End()
 
-	var response dto.TokenResponse
+	// Preserve the parent context for hooks that run outside the transaction.
+	parentCtx := ctx
+
+	var (
+		response dto.TokenResponse
+		user     users.User
+		isNew    bool
+	)
 	err := as.transactor.WithinTransaction(ctx, func(ctx context.Context) error {
 		sessionStr, err := as.stateStore.VerifyAndDelete(ctx, data.State)
 		if err != nil {
@@ -79,7 +90,7 @@ func (as *oauthServiceImpl) HandleOAuthCallback(ctx context.Context, data dto.OA
 			return err
 		}
 
-		user, err := as.getOrCreateUser(ctx, userInfo)
+		user, isNew, err = as.getOrCreateUser(ctx, userInfo)
 		if err != nil {
 			return err
 		}
@@ -93,19 +104,27 @@ func (as *oauthServiceImpl) HandleOAuthCallback(ctx context.Context, data dto.OA
 		response, err = as.sessionSvc.CreateTokenAndSession(ctx, user)
 		return err
 	})
+	if err != nil {
+		return dto.TokenResponse{}, err
+	}
 
-	return response, err
+	if hookErr := as.hooks.CallAfterOAuthLogin(parentCtx, user.ID, data.Provider, isNew); hookErr != nil {
+		logger.Error(hookErr)
+	}
+
+	return response, nil
 }
 
-func (as *oauthServiceImpl) getOrCreateUser(ctx context.Context, userInfo oauth.UserInfo) (users.User, error) {
+func (as *oauthServiceImpl) getOrCreateUser(ctx context.Context, userInfo oauth.UserInfo) (users.User, bool, error) {
 	existingOAuth, err := as.findOAuthAccount(ctx, userInfo.Provider, userInfo.ProviderID)
 	if err != nil {
-		return users.User{}, err
+		return users.User{}, false, err
 	}
 	if !existingOAuth.IsZero() {
-		return existingOAuth.User, nil
+		return existingOAuth.User, false, nil
 	}
-	return as.createNewUserOAuth(ctx, userInfo)
+	user, err := as.createNewUserOAuth(ctx, userInfo)
+	return user, true, err
 }
 
 func (as *oauthServiceImpl) createNewUserOAuth(ctx context.Context, userInfo oauth.UserInfo) (users.User, error) {

--- a/internal/domain/service/session_service.go
+++ b/internal/domain/service/session_service.go
@@ -24,6 +24,7 @@ type sessionService struct {
 	transactor       crud.Transactor
 	sessionRepo      crud.Repository[users.Session]
 	refreshTokenRepo crud.Repository[users.RefreshToken]
+	claimsBuilder    func(ctx context.Context, userID uuid.UUID, baseClaims map[string]any) (map[string]any, error)
 }
 
 func NewSessionService(
@@ -32,6 +33,7 @@ func NewSessionService(
 	transactor crud.Transactor,
 	sessionRepo crud.Repository[users.Session],
 	refreshTokenRepo crud.Repository[users.RefreshToken],
+	claimsBuilder func(ctx context.Context, userID uuid.UUID, baseClaims map[string]any) (map[string]any, error),
 ) *sessionService {
 	return &sessionService{
 		jwtService,
@@ -39,6 +41,7 @@ func NewSessionService(
 		transactor,
 		sessionRepo,
 		refreshTokenRepo,
+		claimsBuilder,
 	}
 }
 
@@ -74,6 +77,14 @@ func (ss *sessionService) RefreshToken(ctx context.Context, request dto.RefreshT
 		rawFingerprint, fgpHash := ss.generateFingerprint()
 		claims := mapper.SessionToAuthData(session, fgpHash)
 
+		if ss.claimsBuilder != nil {
+			builtClaims, err := ss.claimsBuilder(ctx, session.UserID, claims)
+			if err != nil {
+				return err
+			}
+			claims = builtClaims
+		}
+
 		accessToken, err := ss.jwtService.CreateToken(claims)
 		if err != nil {
 			return err
@@ -99,6 +110,15 @@ func (ss *sessionService) CreateTokenAndSession(ctx context.Context, user users.
 	// Create access token
 	rawFingerprint, fgpHash := ss.generateFingerprint()
 	authData := mapper.SessionToAuthData(session, fgpHash)
+
+	if ss.claimsBuilder != nil {
+		builtClaims, err := ss.claimsBuilder(ctx, session.UserID, authData)
+		if err != nil {
+			return dto.TokenResponse{}, err
+		}
+		authData = builtClaims
+	}
+
 	accessToken, err := ss.jwtService.CreateToken(authData)
 	if err != nil {
 		return dto.TokenResponse{}, err

--- a/internal/provider/auth_hooks.go
+++ b/internal/provider/auth_hooks.go
@@ -1,0 +1,69 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/itsLeonB/cashback/internal/domain/service"
+	"github.com/itsLeonB/ungerr"
+)
+
+// NewAuthHooks builds the application-specific auth hooks that wire Cashus
+// business logic into the generic auth flows. Hooks that have no current
+// implementation are left as nil (no-op).
+func NewAuthHooks(
+	pushNotification service.PushNotificationService,
+	profileService service.ProfileService,
+	friendshipService service.FriendshipService,
+) service.AuthHooks {
+	return service.AuthHooks{
+		BeforeLogout: func(ctx context.Context, sessionID uuid.UUID) error {
+			return pushNotification.UnsubscribeBySession(ctx, sessionID)
+		},
+		AfterEmailVerified: func(ctx context.Context, userID, profileID uuid.UUID, claims map[string]any) error {
+			slug, ok := claims["slug"].(string)
+			if !ok || slug == "" {
+				return nil
+			}
+			return associateBySlug(ctx, profileService, friendshipService, profileID, slug)
+		},
+	}
+}
+
+// associateBySlug links a newly verified user's profile to an anonymous
+// profile identified by a slug. It looks up the anonymous profile, finds its
+// owner through the friendship graph, creates a real friendship, and then
+// associates the profiles.
+func associateBySlug(
+	ctx context.Context,
+	profileSvc service.ProfileService,
+	friendshipSvc service.FriendshipService,
+	newProfileID uuid.UUID,
+	slug string,
+) error {
+	anonProfile, err := profileSvc.FindBySlug(ctx, slug)
+	if err != nil {
+		return err
+	}
+
+	// Find the owner of the anonymous profile via friendship
+	friendships, err := friendshipSvc.GetAll(ctx, anonProfile.ID)
+	if err != nil {
+		return err
+	}
+	if len(friendships) == 0 {
+		return ungerr.NotFoundError(fmt.Sprintf("no friendship found for slug %s", slug))
+	}
+
+	ownerProfileID := friendships[0].ProfileID
+
+	// Create real friendship between owner and new user
+	_, err = friendshipSvc.CreateReal(ctx, ownerProfileID, newProfileID)
+	if err != nil {
+		return err
+	}
+
+	// Create RelatedProfile association
+	return profileSvc.Associate(ctx, ownerProfileID, newProfileID, anonProfile.ID)
+}

--- a/internal/provider/service_provider.go
+++ b/internal/provider/service_provider.go
@@ -76,9 +76,15 @@ func ProvideServices(
 	jwt := sekure.NewJwtService(authConfig.Issuer, authConfig.SecretKey, authConfig.TokenDuration)
 	profile := service.NewProfileService(repos.Transactor, repos.Profile, repos.User, repos.Friendship, repos.RelatedProfile, subs, subsLimit)
 	user := service.NewUserService(repos.Transactor, repos.User, profile, repos.PasswordResetToken, coreSvc.Mail)
-	session := service.NewSessionService(jwt, user, repos.Transactor, repos.Session, repos.RefreshToken)
-
 	friendship := service.NewFriendshipService(repos.Transactor, repos.Friendship, profile)
+	pushNotification := service.NewPushNotificationService(repos.PushSubscription, repos.Notification, repos.Transactor, coreSvc.WebPush)
+
+	// hooks assembles the service.AuthHooks{} configuration that wires Cashus
+	// business logic into the generic auth service layer.
+	hooks := NewAuthHooks(pushNotification, profile, friendship)
+
+	session := service.NewSessionService(jwt, user, repos.Transactor, repos.Session, repos.RefreshToken, hooks.ClaimsBuilder)
+
 	friendReq := service.NewFriendshipRequestService(repos.Transactor, friendship, profile, repos.FriendshipRequest, coreSvc.Queue)
 
 	groupExpense := service.NewGroupExpenseService(friendship, repos.GroupExpense, repos.Transactor, fee.NewFeeCalculatorRegistry(), repos.OtherFee, repos.ExpenseBill, coreSvc.LLM, coreSvc.Image, coreSvc.Queue, coreSvc.Langfuse, profile)
@@ -86,14 +92,12 @@ func ProvideServices(
 	transferMethod := service.NewTransferMethodService(repos.TransferMethod, coreSvc.Storage, appConfig.BucketNameTransferMethods, appembed.TransferMethodAssets)
 	debt := service.NewDebtService(repos.DebtTransaction, transferMethod, friendship, profile, groupExpense, coreSvc.Queue)
 
-	pushNotification := service.NewPushNotificationService(repos.PushSubscription, repos.Notification, repos.Transactor, coreSvc.WebPush)
-
 	sessionCache := cache.NewInMemoryCache[uuid.UUID](authConfig.TokenDuration)
 	providerSvc := oauth.NewProviderService(config.Global.OAuthProviders)
 
 	return &Services{
-		Auth:    service.NewAuthService(jwt, repos.Transactor, user, coreSvc.Mail, appConfig.RegisterVerificationUrl, appConfig.ResetPasswordUrl, authConfig.HashCost, pushNotification, session, profile, friendship, sessionCache),
-		OAuth:   service.NewOAuthService(repos.Transactor, providerSvc, repos.OAuthAccount, coreSvc.State, user, session),
+		Auth:    service.NewAuthService(jwt, repos.Transactor, user, coreSvc.Mail, appConfig.RegisterVerificationUrl, appConfig.ResetPasswordUrl, authConfig.HashCost, session, sessionCache, hooks),
+		OAuth:   service.NewOAuthService(repos.Transactor, providerSvc, repos.OAuthAccount, coreSvc.State, user, session, hooks),
 		Session: session,
 		Captcha: service.NewTurnstileService(authConfig.TurnstileSecretKey),
 


### PR DESCRIPTION
- Add AuthHooks struct with BeforeLogout, AfterEmailVerified, AfterOAuthLogin, and ClaimsBuilder hooks
- Remove push/profile/friendship dependencies from authServiceImpl
- Delegate Logout push cleanup to hooks.BeforeLogout
- Delegate VerifyRegistration slug association to hooks.AfterEmailVerified
- Add claimsBuilder hook to sessionService for custom JWT claims
- Track isNew in OAuth getOrCreateUser and fire AfterOAuthLogin
- Wire hooks in provider layer via NewAuthHooks constructor
- Add nil-safe helper methods on AuthHooks
- Fix AfterOAuthLogin to use parent context after transaction
- Use ungerr.NotFoundError in provider-layer associateBySlug
- Add .kimchi/ to .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced authentication hooks enabling custom callbacks for logout, email verification, OAuth login, and token claims customization.

* **Refactoring**
  * Restructured authentication and OAuth services to use hook-based extensibility pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->