### PR TITLE
feat: migrate payment gateway from Midtrans to iPaymu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,9 +62,14 @@ ADMIN_AUTH_TOKEN_DURATION=1h
 ADMIN_AUTH_ISSUER=cashdash
 ADMIN_AUTH_HASH_COST=10
 
-PAYMENT_GATEWAY=midtrans
+PAYMENT_GATEWAY=ipaymu
 PAYMENT_SERVER_KEY=
-PAYMENT_ENVIRONMENT=sandbox
+PAYMENT_VA=
+PAYMENT_BASE_URL=https://sandbox.ipaymu.com
+PAYMENT_RETURN_URL=https://app.cashus.app/payment/return
+PAYMENT_NOTIFY_URL=https://api.cashus.app/api/v1/payments/ipaymu/notifications
+PAYMENT_CANCEL_URL=https://app.cashus.app/payment/return?status=cancel
+PAYMENT_NOTIFY_SECRET=
 
 FLAG_SUBSCRIPTION_PURCHASE_ENABLED=false
 FLAG_CLIENT_KEY=your-flag-key

--- a/internal/adapters/http/handler/payment_handler.go
+++ b/internal/adapters/http/handler/payment_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/itsLeonB/cashback/internal/appconstant"
 	dto "github.com/itsLeonB/cashback/internal/domain/dto/monetization"
 	service "github.com/itsLeonB/cashback/internal/domain/service/monetization"
+	"github.com/itsLeonB/cashback/internal/domain/service/monetization/payment"
 	_ "github.com/itsLeonB/ginkgo/pkg/response"
 	"github.com/itsLeonB/ginkgo/pkg/server"
 )
@@ -16,7 +17,7 @@ type PaymentHandler struct {
 	svc service.PaymentService
 }
 
-// HandleNotification godoc
+// HandleMidtransNotification godoc
 // @Summary      Handle Midtrans payment notification
 // @Tags         payments
 // @Accept       json
@@ -25,14 +26,54 @@ type PaymentHandler struct {
 // @Success      200  {object}  map[string]any
 // @Failure      400  {object}  map[string]any
 // @Router       /payments/midtrans/notifications [post]
-func (ph *PaymentHandler) HandleNotification() gin.HandlerFunc {
-	return server.Handler("PaymentHandler.HandleNotification", http.StatusOK, func(ctx *gin.Context) (any, error) {
+func (ph *PaymentHandler) HandleMidtransNotification() gin.HandlerFunc {
+	return server.Handler("PaymentHandler.HandleMidtransNotification", http.StatusOK, func(ctx *gin.Context) (any, error) {
 		req, err := server.BindJSON[dto.MidtransNotificationPayload](ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		return nil, ph.svc.HandleNotification(ctx.Request.Context(), req)
+		payload := payment.NotificationPayload{
+			OrderID:   req.OrderID,
+			Signature: req.SignatureKey,
+			Extra: map[string]string{
+				"status_code":    req.StatusCode,
+				"gross_amount":   req.GrossAmount,
+				"status_message": req.StatusMessage,
+			},
+		}
+
+		return nil, ph.svc.HandleNotification(ctx.Request.Context(), payload)
+	})
+}
+
+// HandleIPaymuNotification godoc
+// @Summary      Handle iPaymu payment notification
+// @Tags         payments
+// @Accept       json
+// @Produce      json
+// @Param        body body dto.IPaymuNotificationPayload true "iPaymu notification payload"
+// @Success      200  {object}  map[string]any
+// @Failure      400  {object}  map[string]any
+// @Router       /payments/ipaymu/notifications [post]
+func (ph *PaymentHandler) HandleIPaymuNotification() gin.HandlerFunc {
+	return server.Handler("PaymentHandler.HandleIPaymuNotification", http.StatusOK, func(ctx *gin.Context) (any, error) {
+		req, err := server.BindJSON[dto.IPaymuNotificationPayload](ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		payload := payment.NotificationPayload{
+			OrderID:   req.ReferenceID,
+			RawStatus: req.Status,
+			Signature: ctx.Query("secret"),
+			Extra: map[string]string{
+				"trx_id":      req.TrxID,
+				"status_code": req.StatusCode,
+			},
+		}
+
+		return nil, ph.svc.HandleNotification(ctx.Request.Context(), payload)
 	})
 }
 

--- a/internal/adapters/http/register_routes.go
+++ b/internal/adapters/http/register_routes.go
@@ -44,7 +44,7 @@ func RegisterRoutes(router *gin.Engine, configs config.Config, services *provide
 
 	sentinelGin.RegisterHealth(router, httpserver.NewHealthHandler())
 
-	if configs.App.Env != "release" {
+	if configs.Env != "release" {
 		sentinelGin.RegisterPprof(router, httpserver.DefaultPprofConfig())
 		routes.RegisterTestRoutes(router)
 	}

--- a/internal/adapters/http/routes/api_routes.go
+++ b/internal/adapters/http/routes/api_routes.go
@@ -18,7 +18,8 @@ func RegisterAPIRoutes(router *gin.Engine, handlers *handler.Handlers, authMiddl
 	{
 		v1 := apiRoutes.Group("/v1")
 		{
-			v1.POST("/payments/midtrans/notifications", handlers.Payment.HandleNotification())
+			v1.POST("/payments/midtrans/notifications", handlers.Payment.HandleMidtransNotification())
+			v1.POST("/payments/ipaymu/notifications", handlers.Payment.HandleIPaymuNotification())
 			v1.GET("/plans", handlers.Plan.HandleGetActive())
 			v1.GET("/public/profiles/:slug", handlers.Public.HandleGetPublicProfile())
 

--- a/internal/adapters/http/server.go
+++ b/internal/adapters/http/server.go
@@ -17,7 +17,7 @@ func Setup(configs config.Config) (*httpserver.Server, func(), error) {
 		return nil, nil, err
 	}
 
-	gin.SetMode(configs.App.Env)
+	gin.SetMode(configs.Env)
 	r := gin.New()
 	r.HandleMethodNotAllowed = true
 

--- a/internal/core/config/payment_config.go
+++ b/internal/core/config/payment_config.go
@@ -1,9 +1,14 @@
 package config
 
 type Payment struct {
-	Gateway   string `default:"midtrans"`
-	ServerKey string `split_words:"true" required:"true"`
-	Env       string `default:"sandbox"`
+	Gateway      string `default:"ipaymu"`
+	ServerKey    string `split_words:"true" required:"true"`
+	Va           string `split_words:"true"`
+	BaseUrl      string `split_words:"true" default:"https://sandbox.ipaymu.com"`
+	ReturnUrl    string `split_words:"true"`
+	NotifyUrl    string `split_words:"true"`
+	CancelUrl    string `split_words:"true"`
+	NotifySecret string `split_words:"true"` // shared secret for callback validation
 }
 
 func (Payment) Prefix() string {

--- a/internal/domain/dto/monetization/payment_dto.go
+++ b/internal/domain/dto/monetization/payment_dto.go
@@ -39,6 +39,13 @@ type MidtransNotificationPayload struct {
 	StatusMessage string `json:"status_message"`
 }
 
+type IPaymuNotificationPayload struct {
+	TrxID       string `json:"trx_id" binding:"required"`
+	ReferenceID string `json:"reference_id" binding:"required"`
+	StatusCode  string `json:"status_code" binding:"required"`
+	Status      string `json:"status" binding:"required"`
+}
+
 type UpdatePaymentRequest struct {
 	ID       uuid.UUID       `json:"-"`
 	Status   string          `json:"status" binding:"required,oneof=pending processing paid canceled error expired"`

--- a/internal/domain/service/monetization/payment/ipaymu_gateway.go
+++ b/internal/domain/service/monetization/payment/ipaymu_gateway.go
@@ -1,0 +1,196 @@
+package payment
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/itsLeonB/cashback/internal/core/config"
+	"github.com/itsLeonB/cashback/internal/core/logger"
+	"github.com/itsLeonB/cashback/internal/core/otel"
+	entity "github.com/itsLeonB/cashback/internal/domain/entity/monetization"
+	"github.com/itsLeonB/ungerr"
+)
+
+type ipaymuGateway struct {
+	apiKey       string
+	va           string
+	baseURL      string
+	returnURL    string
+	notifyURL    string
+	cancelURL    string
+	notifySecret string
+	client       *http.Client
+}
+
+func newIPaymuGateway(cfg config.Payment) (*ipaymuGateway, error) {
+	notifyURL := cfg.NotifyUrl
+	if cfg.NotifySecret != "" {
+		sep := "?"
+		if strings.Contains(notifyURL, "?") {
+			sep = "&"
+		}
+		notifyURL += sep + "secret=" + cfg.NotifySecret
+	}
+
+	return &ipaymuGateway{
+		apiKey:       cfg.ServerKey,
+		va:           cfg.Va,
+		baseURL:      cfg.BaseUrl,
+		returnURL:    cfg.ReturnUrl,
+		notifyURL:    notifyURL,
+		cancelURL:    cfg.CancelUrl,
+		notifySecret: cfg.NotifySecret,
+		client:       &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+func (g *ipaymuGateway) Provider() string {
+	return "ipaymu"
+}
+
+func (g *ipaymuGateway) CreateTransaction(ctx context.Context, payment entity.Payment) (entity.Payment, error) {
+	ctx, span := otel.Tracer.Start(ctx, "ipaymuGateway.CreateTransaction")
+	defer span.End()
+
+	body := map[string]any{
+		"product":     []string{"Cashus Subscription"},
+		"qty":         []int{1},
+		"price":       []int64{payment.Amount.IntPart()},
+		"amount":      payment.Amount.IntPart(),
+		"returnUrl":   g.returnURL,
+		"notifyUrl":   g.notifyURL,
+		"cancelUrl":   g.cancelURL,
+		"referenceId": payment.ID.String(),
+		"expired":     24,
+		"comments":    "Cashus subscription",
+	}
+
+	respBody, err := g.doRequest(ctx, "/api/v2/payment", body)
+	if err != nil {
+		return entity.Payment{}, ungerr.Wrap(err, "error creating ipaymu transaction")
+	}
+
+	var result struct {
+		Status  int    `json:"Status"`
+		Message string `json:"Message"`
+		Data    struct {
+			SessionID     string `json:"SessionId"`
+			TransactionID int    `json:"TransactionId"`
+			URL           string `json:"Url"`
+		} `json:"Data"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return entity.Payment{}, ungerr.Wrap(err, "error parsing ipaymu response")
+	}
+	if result.Status != 200 {
+		return entity.Payment{}, ungerr.Unknownf("ipaymu error: %s", result.Message)
+	}
+
+	// ponytail: GatewayTransactionID stores the redirect URL for iPaymu (frontend reads this to redirect user).
+	// GatewayEventID stores the numeric transaction ID for status checks.
+	payment.GatewayTransactionID = sql.NullString{String: result.Data.URL, Valid: true}
+	payment.GatewayEventID = sql.NullString{String: strconv.Itoa(result.Data.TransactionID), Valid: true}
+
+	return payment, nil
+}
+
+func (g *ipaymuGateway) ValidateAndCheckStatus(ctx context.Context, payload NotificationPayload) (entity.PaymentStatus, error) {
+	ctx, span := otel.Tracer.Start(ctx, "ipaymuGateway.ValidateAndCheckStatus")
+	defer span.End()
+
+	// Validate shared secret from notify URL query param
+	if g.notifySecret != "" {
+		if subtle.ConstantTimeCompare([]byte(payload.Signature), []byte(g.notifySecret)) != 1 {
+			return entity.ErrorPayment, ungerr.Unknown("invalid notification secret")
+		}
+	}
+
+	// Server-side confirmation: call iPaymu transaction API to verify actual status
+	trxID := payload.Extra["trx_id"]
+	if trxID == "" {
+		return entity.ErrorPayment, ungerr.Unknown("missing trx_id in ipaymu notification")
+	}
+
+	body := map[string]any{"transactionId": trxID}
+	respBody, err := g.doRequest(ctx, "/api/v2/transaction", body)
+	if err != nil {
+		return entity.ErrorPayment, ungerr.Wrap(err, "error confirming ipaymu transaction status")
+	}
+
+	var result struct {
+		Status int `json:"Status"`
+		Data   struct {
+			StatusCode int    `json:"StatusCode"`
+			Status     string `json:"Status"`
+		} `json:"Data"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return entity.ErrorPayment, ungerr.Wrap(err, "error parsing ipaymu status response")
+	}
+
+	return g.mapStatus(result.Data.Status)
+}
+
+func (g *ipaymuGateway) mapStatus(status string) (entity.PaymentStatus, error) {
+	switch strings.ToLower(status) {
+	case "berhasil", "successful":
+		return entity.PaidPayment, nil
+	case "pending":
+		return entity.PendingPayment, nil
+	case "expired":
+		return entity.ExpiredPayment, nil
+	case "gagal", "failed":
+		return entity.ErrorPayment, fmt.Errorf("payment failed")
+	default:
+		return entity.ErrorPayment, ungerr.Unknownf("unhandled ipaymu status: %s", status)
+	}
+}
+
+func (g *ipaymuGateway) doRequest(ctx context.Context, path string, body map[string]any) ([]byte, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Signature: HMAC-SHA256
+	bodyHash := sha256.Sum256(jsonBody)
+	bodyHashHex := hex.EncodeToString(bodyHash[:])
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	stringToSign := "POST:" + g.va + ":" + bodyHashHex + ":" + g.apiKey
+	mac := hmac.New(sha256.New, []byte(g.apiKey))
+	mac.Write([]byte(stringToSign))
+	signature := hex.EncodeToString(mac.Sum(nil))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.baseURL+path, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("va", g.va)
+	req.Header.Set("signature", signature)
+	req.Header.Set("timestamp", ts)
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Errorf("error closing response body: %v", err)
+		}
+	}()
+
+	return io.ReadAll(resp.Body)
+}

--- a/internal/domain/service/monetization/payment/midtrans_gateway.go
+++ b/internal/domain/service/monetization/payment/midtrans_gateway.go
@@ -6,11 +6,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/itsLeonB/cashback/internal/core/config"
 	"github.com/itsLeonB/cashback/internal/core/logger"
 	"github.com/itsLeonB/cashback/internal/core/otel"
-	dto "github.com/itsLeonB/cashback/internal/domain/dto/monetization"
 	entity "github.com/itsLeonB/cashback/internal/domain/entity/monetization"
 	"github.com/itsLeonB/ungerr"
 	"github.com/midtrans/midtrans-go"
@@ -28,9 +28,9 @@ func newMidtransGateway(cfg config.Payment) (*midtransGateway, error) {
 	snapClient := &snap.Client{}
 	coreClient := &coreapi.Client{}
 
-	env, err := loadMidtransEnv(cfg.Env)
-	if err != nil {
-		return nil, err
+	env := midtrans.Production
+	if strings.Contains(cfg.BaseUrl, "sandbox") {
+		env = midtrans.Sandbox
 	}
 
 	snapClient.New(cfg.ServerKey, env)
@@ -39,16 +39,6 @@ func newMidtransGateway(cfg config.Payment) (*midtransGateway, error) {
 	return &midtransGateway{snapClient, coreClient, cfg.ServerKey}, nil
 }
 
-func loadMidtransEnv(envCfg string) (midtrans.EnvironmentType, error) {
-	switch envCfg {
-	case "sandbox":
-		return midtrans.Sandbox, nil
-	case "production":
-		return midtrans.Production, nil
-	default:
-		return 0, ungerr.Unknownf("unsupported payment gateway env: %s", envCfg)
-	}
-}
 
 func (mg *midtransGateway) Provider() string {
 	return "midtrans"
@@ -81,20 +71,27 @@ func (mg *midtransGateway) CreateTransaction(ctx context.Context, payment entity
 	return payment, nil
 }
 
-func (mg *midtransGateway) CheckStatus(ctx context.Context, req dto.MidtransNotificationPayload) (entity.PaymentStatus, error) {
-	ctx, span := otel.Tracer.Start(ctx, "midtransGateway.CheckStatus")
+func (mg *midtransGateway) ValidateAndCheckStatus(ctx context.Context, payload NotificationPayload) (entity.PaymentStatus, error) {
+	ctx, span := otel.Tracer.Start(ctx, "midtransGateway.ValidateAndCheckStatus")
 	defer span.End()
 
-	if err := mg.validate(req); err != nil {
-		return entity.ErrorPayment, err
+	// Validate signature
+	statusCode := payload.Extra["status_code"]
+	grossAmount := payload.Extra["gross_amount"]
+	signatureKey := payload.Signature
+
+	checkKey := payload.OrderID + statusCode + grossAmount + mg.serverKey
+	constructedKey := sha512.Sum512([]byte(checkKey))
+	if fmt.Sprintf("%x", constructedKey) != signatureKey {
+		return entity.ErrorPayment, ungerr.Unknown("signature key cannot be validated")
 	}
 
 	coreClient := *mg.coreClient
 	coreClient.Options = &midtrans.ConfigOptions{}
 	coreClient.Options.SetContext(ctx)
-	trxStatusResp, err := coreClient.CheckTransaction(req.OrderID)
+	trxStatusResp, err := coreClient.CheckTransaction(payload.OrderID)
 	if err != nil {
-		return entity.ErrorPayment, ungerr.Wrapf(err, "error checking transaction status of ID: %s", req.OrderID)
+		return entity.ErrorPayment, ungerr.Wrapf(err, "error checking transaction status of ID: %s", payload.OrderID)
 	}
 
 	switch trxStatusResp.TransactionStatus {
@@ -111,11 +108,12 @@ func (mg *midtransGateway) CheckStatus(ctx context.Context, req dto.MidtransNoti
 	case "settlement":
 		return entity.PaidPayment, nil
 	case "deny":
+		statusMessage := payload.Extra["status_message"]
 		var e error
-		if req.StatusMessage == "" {
+		if statusMessage == "" {
 			e = errors.New("unknown")
 		} else {
-			e = errors.New(req.StatusMessage)
+			e = errors.New(statusMessage)
 		}
 		return entity.ErrorPayment, e
 	case "cancel", "expire":
@@ -125,15 +123,4 @@ func (mg *midtransGateway) CheckStatus(ctx context.Context, req dto.MidtransNoti
 	default:
 		return entity.ErrorPayment, ungerr.Unknownf("unhandled transaction status: %s", trxStatusResp.TransactionStatus)
 	}
-}
-
-func (mg *midtransGateway) validate(req dto.MidtransNotificationPayload) error {
-	checkKey := req.OrderID + req.StatusCode + req.GrossAmount + mg.serverKey
-	constructedKey := sha512.Sum512([]byte(checkKey))
-
-	if fmt.Sprintf("%x", constructedKey) == req.SignatureKey {
-		return nil
-	}
-
-	return ungerr.Unknown("signature key cannot be validated")
 }

--- a/internal/domain/service/monetization/payment/payment_gateway.go
+++ b/internal/domain/service/monetization/payment/payment_gateway.go
@@ -4,19 +4,28 @@ import (
 	"context"
 
 	"github.com/itsLeonB/cashback/internal/core/config"
-	dto "github.com/itsLeonB/cashback/internal/domain/dto/monetization"
 	entity "github.com/itsLeonB/cashback/internal/domain/entity/monetization"
 	"github.com/itsLeonB/ungerr"
 )
 
+// NotificationPayload is a gateway-agnostic representation of an incoming payment notification.
+type NotificationPayload struct {
+	OrderID   string // payment UUID
+	RawStatus string // gateway-native status string
+	Signature string // for validation
+	Extra     map[string]string
+}
+
 type Gateway interface {
 	Provider() string
 	CreateTransaction(ctx context.Context, payment entity.Payment) (entity.Payment, error)
-	CheckStatus(ctx context.Context, req dto.MidtransNotificationPayload) (entity.PaymentStatus, error)
+	ValidateAndCheckStatus(ctx context.Context, payload NotificationPayload) (entity.PaymentStatus, error)
 }
 
 func NewGateway(cfg config.Payment) (Gateway, error) {
 	switch cfg.Gateway {
+	case "ipaymu":
+		return newIPaymuGateway(cfg)
 	case "midtrans":
 		return newMidtransGateway(cfg)
 	default:

--- a/internal/domain/service/monetization/payment_service.go
+++ b/internal/domain/service/monetization/payment_service.go
@@ -22,7 +22,7 @@ import (
 
 type PaymentService interface {
 	NewPurchase(ctx context.Context, req dto.PurchaseSubscriptionRequest) (dto.PaymentResponse, error)
-	HandleNotification(ctx context.Context, req dto.MidtransNotificationPayload) error
+	HandleNotification(ctx context.Context, payload payment.NotificationPayload) error
 	MakePayment(ctx context.Context, subscriptionID uuid.UUID) (dto.PaymentResponse, error)
 
 	// Admin
@@ -118,7 +118,7 @@ func (ps *paymentService) create(ctx context.Context, req dto.NewPaymentRequest)
 	return mapper.PaymentToResponse(requestedPayment), nil
 }
 
-func (ps *paymentService) HandleNotification(ctx context.Context, req dto.MidtransNotificationPayload) error {
+func (ps *paymentService) HandleNotification(ctx context.Context, payload payment.NotificationPayload) error {
 	ctx, span := otel.Tracer.Start(ctx, "PaymentService.HandleNotification")
 	defer span.End()
 
@@ -126,7 +126,7 @@ func (ps *paymentService) HandleNotification(ctx context.Context, req dto.Midtra
 		return err
 	}
 
-	newStatus, statusErr := ps.gateway.CheckStatus(ctx, req)
+	newStatus, statusErr := ps.gateway.ValidateAndCheckStatus(ctx, payload)
 	if statusErr != nil {
 		if newStatus == "" {
 			return statusErr
@@ -135,7 +135,7 @@ func (ps *paymentService) HandleNotification(ctx context.Context, req dto.Midtra
 	}
 
 	return ps.transactor.WithinTransaction(ctx, func(ctx context.Context) error {
-		id, err := ezutil.Parse[uuid.UUID](req.OrderID)
+		id, err := ezutil.Parse[uuid.UUID](payload.OrderID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Generalize Gateway interface with NotificationPayload (decouple from Midtrans)
- Implement iPaymu gateway with redirect payment flow
- Add server-side status verification via /api/v2/transaction
- Add shared secret validation for callback notifications
- Make all URLs configurable via env (base, return, notify, cancel)
- Add iPaymu notification webhook handler and route
- Keep Midtrans gateway for backward compatibility
- Fix pre-existing staticcheck lint issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a second payment provider alongside the existing one.
  * Introduced separate notification endpoints for each supported payment provider.

* **Bug Fixes**
  * Updated payment notification handling to work with provider-specific request formats.
  * Improved configuration defaults for the new payment setup, including updated example values and URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->