### PR TITLE
fix: return otherfee to response when confirming expense

### DIFF
--- a/internal/adapters/db/postgres/migrations/20260707130352_add_on_delete_cascade_to_other_fee_participants.sql
+++ b/internal/adapters/db/postgres/migrations/20260707130352_add_on_delete_cascade_to_other_fee_participants.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE group_expense_other_fee_participants
+DROP CONSTRAINT group_expense_other_fee_participants_other_fee_id_fkey;
+
+ALTER TABLE group_expense_other_fee_participants
+ADD CONSTRAINT group_expense_other_fee_participants_other_fee_id_fkey
+FOREIGN KEY (other_fee_id) REFERENCES group_expense_other_fees(id) ON DELETE CASCADE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE group_expense_other_fee_participants
+DROP CONSTRAINT group_expense_other_fee_participants_other_fee_id_fkey;
+
+ALTER TABLE group_expense_other_fee_participants
+ADD CONSTRAINT group_expense_other_fee_participants_other_fee_id_fkey
+FOREIGN KEY (other_fee_id) REFERENCES group_expense_other_fees(id);
+-- +goose StatementEnd

--- a/internal/domain/entity/expenses/group_expense_entity.go
+++ b/internal/domain/entity/expenses/group_expense_entity.go
@@ -47,6 +47,7 @@ func (GroupExpense) coreRelations() []string {
 	return []string{
 		"Items",
 		"OtherFees",
+		"OtherFees.Participants",
 		"Payer",
 		"Creator",
 		"Items.Participants",
@@ -58,7 +59,7 @@ func (GroupExpense) coreRelations() []string {
 }
 
 func (ge GroupExpense) ForCalculationRelations() []string {
-	return append(ge.coreRelations(), "OtherFees.Participants", "OtherFees.Participants.Profile")
+	return append(ge.coreRelations(), "OtherFees.Participants.Profile")
 }
 
 func (ge GroupExpense) ForDisplayRelations() []string {

--- a/internal/domain/service/group_expense_service.go
+++ b/internal/domain/service/group_expense_service.go
@@ -176,7 +176,7 @@ func (ges *groupExpenseServiceImpl) ConfirmDraft(ctx context.Context, id, profil
 			return err
 		}
 
-		updatedParticipants, err := ges.calculateUpdatedExpenseParticipants(ctx, groupExpense)
+		updatedParticipants, updatedOtherFees, err := ges.calculateUpdatedExpenseParticipants(ctx, groupExpense)
 		if err != nil {
 			return err
 		}
@@ -194,6 +194,7 @@ func (ges *groupExpenseServiceImpl) ConfirmDraft(ctx context.Context, id, profil
 		}
 
 		groupExpense.Participants = updatedParticipants
+		groupExpense.OtherFees = updatedOtherFees
 
 		if !dryRun {
 			if err = ges.taskQueue.Enqueue(ctx, message.ExpenseConfirmed{ID: id}); err != nil {
@@ -223,7 +224,7 @@ func validateForConfirmation(groupExpense expenses.GroupExpense) error {
 	return nil
 }
 
-func (ges *groupExpenseServiceImpl) calculateUpdatedExpenseParticipants(ctx context.Context, groupExpense expenses.GroupExpense) ([]expenses.ExpenseParticipant, error) {
+func (ges *groupExpenseServiceImpl) calculateUpdatedExpenseParticipants(ctx context.Context, groupExpense expenses.GroupExpense) ([]expenses.ExpenseParticipant, []expenses.OtherFee, error) {
 	participantsMap := make(map[uuid.UUID]*expenses.ExpenseParticipant, len(groupExpense.Participants))
 	for _, participant := range groupExpense.Participants {
 		participant.ShareAmount = decimal.Zero
@@ -232,13 +233,13 @@ func (ges *groupExpenseServiceImpl) calculateUpdatedExpenseParticipants(ctx cont
 
 	for _, item := range groupExpense.Items {
 		if len(item.Participants) < 1 {
-			return nil, ungerr.UnprocessableEntityError(fmt.Sprintf("item %s does not have participants", item.Name))
+			return nil, nil, ungerr.UnprocessableEntityError(fmt.Sprintf("item %s does not have participants", item.Name))
 		}
 		for _, participant := range item.Participants {
 			amountToAdd := participant.AllocatedAmount
 			expenseParticipant, ok := participantsMap[participant.ProfileID]
 			if !ok {
-				return nil, ungerr.Unknownf("profile ID: %s is not found in expense participants", participant.ProfileID.String())
+				return nil, nil, ungerr.Unknownf("profile ID: %s is not found in expense participants", participant.ProfileID.String())
 			}
 			expenseParticipant.ShareAmount = expenseParticipant.ShareAmount.Add(amountToAdd)
 		}
@@ -253,14 +254,14 @@ func (ges *groupExpenseServiceImpl) calculateUpdatedExpenseParticipants(ctx cont
 
 	updatedOtherFees, err := ges.calculateOtherFeeSplits(ctx, groupExpense)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, fee := range updatedOtherFees {
 		for _, participant := range fee.Participants {
 			expenseParticipant, ok := participantsMap[participant.ProfileID]
 			if !ok {
-				return nil, ungerr.Unknown("missing participant profile from other fee")
+				return nil, nil, ungerr.Unknown("missing participant profile from other fee")
 			}
 			expenseParticipant.ShareAmount = expenseParticipant.ShareAmount.Add(participant.ShareAmount)
 		}
@@ -271,7 +272,7 @@ func (ges *groupExpenseServiceImpl) calculateUpdatedExpenseParticipants(ctx cont
 		finalParticipants = append(finalParticipants, *participant)
 	}
 
-	return finalParticipants, nil
+	return finalParticipants, updatedOtherFees, nil
 }
 
 func (ges *groupExpenseServiceImpl) calculateOtherFeeSplits(ctx context.Context, groupExpense expenses.GroupExpense) ([]expenses.OtherFee, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Confirming a draft expense now recalculates both participant shares and other-fee splits, helping keep totals accurate.
  * Deleting an expense fee now automatically removes its related participant entries, reducing the chance of leftover or inconsistent records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->